### PR TITLE
Hide wrapper method frames from traceback output

### DIFF
--- a/src/navmazing/_navigator.py
+++ b/src/navmazing/_navigator.py
@@ -57,6 +57,7 @@ class Navigate:
 
         then its go method will be used for doing the actual steps
         """
+        __tracebackhide__ = True
         if isinstance(cls_or_obj, type):
             warnings.warn(
                 f"navigation to types like {cls_or_obj!r} is deprecated,"
@@ -71,12 +72,6 @@ class Navigate:
                     map(repr, args),
                     (f"{key}={value!r}" for key, value in kwargs.items()),
                 )
-            )
-            warnings.warn(
-                f"additional navigation args are deprecated, ({args_str}) was given\n"
-                "use auxiliary classes to register configured locations",
-                category=DeprecationWarning,
-                stacklevel=2,
             )
         nav = self.get_class(cls_or_obj, name)
         return nav(cls_or_obj, self, self.logger).go(0, *args, **kwargs)


### PR DESCRIPTION
## Summary by Sourcery

Adjust navigation helper to reduce noise from internal frames and deprecation warnings during navigation calls.

Enhancements:
- Hide internal navigate helper frames from tracebacks to reduce debugging noise.
- Stop emitting deprecation warnings for additional navigation arguments when invoking navigation targets.